### PR TITLE
Allow Config URLs

### DIFF
--- a/client/src/db.d.ts
+++ b/client/src/db.d.ts
@@ -1,4 +1,5 @@
 declare let isDbReady: Promise<boolean>;
 declare function initDb(baseUrl?: string, dbName?: string): Promise<void>;
+declare function initDbConfig(baseUrl?: string, fileName?: string): Promise<void>;
 declare function query<T>(q: string): Promise<T>;
-export { initDb, query, isDbReady };
+export { initDb, initDbConfig, query, isDbReady };

--- a/client/src/db.ts
+++ b/client/src/db.ts
@@ -26,6 +26,20 @@ async function initDb(
   setDbReady(true)
 }
 
+async function initDbConfig(baseUrl = window.location.origin + "assets/", fileName = "config.json") {
+  worker = await createDbWorker(
+    [
+      {
+        from: "jsonconfig",
+        configUrl: fileName
+      },
+    ],
+    baseUrl + "sqlite.worker.js",
+    baseUrl + "sql-wasm.wasm"
+  );
+  setDbReady(true)
+}
+
 async function query<T = Array<Record<string, any>>>(q: string): Promise<T> {
   if (!worker) {
     console.warn("Waiting for db initialization before querying")
@@ -34,4 +48,4 @@ async function query<T = Array<Record<string, any>>>(q: string): Promise<T> {
   return (await worker.db.query(q)) as T;
 }
 
-export { initDb, query, isDbReady }
+export { initDb, initDbConfig, query, isDbReady }


### PR DESCRIPTION
https://github.com/phiresky/sql.js-httpvfs allows split DBs as mentioned in the README. It takes in a json config file instead of a DB file as an argument.

Kindly publish on npm as well.